### PR TITLE
Solve issue with loading jvm when using AdoptJDK or Adoptium

### DIFF
--- a/Source/JVMLauncher.cpp
+++ b/Source/JVMLauncher.cpp
@@ -331,6 +331,11 @@ void JVMLauncher::launch()
 
 		DEBUG_SHOW( tstring(_T("pBestJvmInfo->toString()=")) + pBestJvmInfo->toString() );
 
+	    // On some Windows environments with AdoptJDK or Adoptium the DLLs couldn't be loaded.
+	    // Specifically add the jre dlls to the dll search directory.
+		tstring binpath = pBestJvmInfo->getJavaHomePath() + tstring(_T("\\bin\\"));
+		SetDllDirectory(binpath.c_str());
+
 		JNIEnv* pJniEnvironment;
 		JavaVM* pJvm;
 		jint result;


### PR DESCRIPTION
I ran into the issue below when starting the adoptium temurin jre 8.0.312 with Janel.exe. For some reason a few random Windows machines wouldn't be able to locate the dlls awt.dll required.

```
java.lang.UnsatisfiedLinkError: jre\jre-temurin-8.0.312\bin\awt.dll: Can't find dependent libraries
	at java.lang.ClassLoader$NativeLibrary.load(Native Method)
	at java.lang.ClassLoader.loadLibrary0(ClassLoader.java:1934)
	at java.lang.ClassLoader.loadLibrary(ClassLoader.java:1838)
	at java.lang.Runtime.loadLibrary0(Runtime.java:871)
	at java.lang.System.loadLibrary(System.java:1124)
	at java.awt.Toolkit$3.run(Toolkit.java:1636)
	at java.awt.Toolkit$3.run(Toolkit.java:1634)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.awt.Toolkit.loadLibraries(Toolkit.java:1633)
	at java.awt.Toolkit.<clinit>(Toolkit.java:1670)
	at java.awt.Component.<clinit>(Component.java:593)
	at javax.swing.ImageIcon$2.run(ImageIcon.java:130)
	at javax.swing.ImageIcon$2.run(ImageIcon.java:128)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.swing.ImageIcon.createNoPermsComponent(ImageIcon.java:127)
	at javax.swing.ImageIcon.access$000(ImageIcon.java:69)
	at javax.swing.ImageIcon$1.run(ImageIcon.java:103)
	at javax.swing.ImageIcon$1.run(ImageIcon.java:100)
	at java.security.AccessController.doPrivileged(Native Method)
```

With some Googling I found this thread https://github.com/adoptium/adoptium-support/issues/135 and with some trial and error this PR solves the issue.

I tried a few oracle JRE's aswell and this change doesn't seem to break anything.